### PR TITLE
Make flow capture work when mitm is in "upstream" mode.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release History
 
 ## Unreleased: mitmproxy next
-
+* Fix flow capture when using upstream proxy mode.
 
 
 ## 07 April 2023: mitmproxy 9.0.1

--- a/mitmproxy/addons/browserup/har/flow_capture.py
+++ b/mitmproxy/addons/browserup/har/flow_capture.py
@@ -141,9 +141,10 @@ class FlowCaptureMixin(object):
 
         har_entry['timings'] = t
 
-        if flow.server_conn.connected:
+        if flow.server_conn.peername:
             har_entry["serverIPAddress"] = str(
-                flow.server_conn.ip_address[0])
+                flow.server_conn.peername[0]
+            )
 
         flow.set_har_entry(har_entry)
         logging.debug('Populated har entry for response: {}, entry: {}'.format(flow.request.url, str(har_entry)))


### PR DESCRIPTION
When we use an upstream proxy, it does not populate the server ip address after connecting (see tunnel.py). So being connected does not imply we have a value for the server ip address, instead just set the serverIPAddress if we have a value for it.

User peername instead of ip_address because ip_address is deprecated.

#### Checklist

 - I couldn't find any applicable tests
 - I have added an entry to the CHANGELOG.
